### PR TITLE
Fix relative mouse motion

### DIFF
--- a/ga/module/ctrl-sdl/ctrl-sdl.cpp
+++ b/ga/module/ctrl-sdl/ctrl-sdl.cpp
@@ -433,8 +433,8 @@ sdlmsg_replay_native(sdlmsg_t *msg) {
 			}
 			in.mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE;
 		} else {
-			in.mi.dx = (short) (scaleFactorX * msgm->mouseRelX);
-			in.mi.dy = (short) (scaleFactorY * msgm->mouseRelY);
+			in.mi.dx = (short) (scaleFactorX * (short) msgm->mouseRelX);
+			in.mi.dy = (short) (scaleFactorY * (short) msgm->mouseRelY);
 			in.mi.dwFlags = MOUSEEVENTF_MOVE;
 		}
 		SendInput(1, &in, sizeof(in));


### PR DESCRIPTION
When `scaleFactor` is not equal to 1, it returned incorrect value for negative relative motion. Converting to signed value before multiplication fixes it.