### PR TITLE
Fixed missing LoadLibrary call

### DIFF
--- a/ga/server/event-driven/ga-hook.cpp
+++ b/ga/server/event-driven/ga-hook.cpp
@@ -423,8 +423,10 @@ hook_dxgi(const char *hook_type, const char *hook_method) {
 	HMODULE hMod;
 	//
 	if((hMod = GetModuleHandle("dxgi.dll")) == NULL) {
-		ga_error("Load dxgi.dll failed.\n");
-		return -1;
+		if((hMod = LoadLibrary("dxgi.dll")) == NULL) {
+			ga_error("Load dxgi.dll failed.\n");
+			return -1;
+		}
 	}
 	//
 	pCreateDXGIFactory = (TCreateDXGIFactory) GetProcAddress(hMod, "CreateDXGIFactory");


### PR DESCRIPTION
Fixed missing LoadLibrary call for dxgi.dll. d3d9 and d3d10 dlls are loaded the same way